### PR TITLE
[Bug] change uor-framework.github.io to universalreference.io

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -44,11 +44,11 @@ orgs:
         default_branch: main
         description: UOR Client
         has_projects: true
-        homepage: https://uor-framework.github.io/
+        homepage: https://universalreference.io/
       uor-framework:
         default_branch: main
         has_projects: true
-      uor-framework.github.io:
+      universalreference:
         default_branch: main
         description: Public GH Pages Repository
         has_projects: true


### PR DESCRIPTION
Fixes:
- Latest Peribolos run re-created [uor-framework/uor-framework.github.io](https://github.com/uor-framework/uor-framework.github.io)
- Replaces broken legacy URL link in [uor-framework/uor-client-go](https://github.com/uor-framework/uor-client-go)