### PR TITLE
docs: updates uor-framework to emporous

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Local
+.idea
+*.swp
+.vscode

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
 # Community Code of Conduct
 
-The UOR Framework follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
+Emporous follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2022 Emporous Authors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # .github
-UOR Framework
+Emporous

--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -1,5 +1,5 @@
 orgs:
-  uor-framework:
+  emporous:
     admins:
       - sabre1041
       - afflom
@@ -9,8 +9,8 @@ orgs:
     billing_email: alexander.flom@gmail.com
     company: ""
     default_repository_permission: read
-    description: Universal Object Reference Framework | Programmable Data
-    email: uor-framework@googlegroups.com
+    description: The smart proxy for container registries
+    email: emporous@googlegroups.com
     has_organization_projects: true
     has_repository_projects: true
     location: ""
@@ -21,11 +21,11 @@ orgs:
       - day0hero
       - sfxworks
     members_can_create_repositories: true
-    name: UOR Framework
+    name: Emporous
     repos:
       .github:
         default_branch: main
-        description: UOR Framework
+        description: Emporous
         has_projects: true
       cncf-distribution:
         default_branch: main
@@ -37,7 +37,7 @@ orgs:
         has_projects: true
       examples:
         default_branch: main
-        description: UOR example use-cases and demos
+        description: Emporous example use-cases and demos
         has_projects: true
       organization:
         default_branch: main
@@ -46,14 +46,14 @@ orgs:
         private: true
       samples:
         default_branch: main
-        description: This repo contains reference implementations of sample content to demonstrate UOR core functionality
+        description: This repo contains reference implementations of sample content to demonstrate Emporous core functionality
         has_projects: true
-      uor-client-go:
+      emporous-go:
         default_branch: main
-        description: UOR Client
+        description: Emporous client libraries and CLI implementation
         has_projects: true
         homepage: https://universalreference.io/
-      uor-framework:
+      emporous-docs:
         default_branch: main
         has_projects: true
       universalreference.io:
@@ -62,7 +62,7 @@ orgs:
         has_projects: true
       collection-spec:
         default_branch: main
-        description: UOR Collection Format
+        description: Emporous Collection Format
         has_projects: true
     teams:
       ci:

--- a/profile/README.md
+++ b/profile/README.md
@@ -9,9 +9,9 @@ Emporous describes a single API that can be used to interact with any element wi
 [Here](https://universalreference.io/docs/category/getting-started) is a simple walk-through with the Emporous Client
 CLI and introduction to Emporous Concepts
 
-### UOR Client
+### Emporous Client
 
-The UOR Client libraries and CLI are in located in the [uor-client-go](https://github.com/emporous/emporous-go) repo.
+The Emporous Client libraries and CLI are in located in the [emporous-go](https://github.com/emporous/emporous-go) repo.
 The CLI is the reference implementation of the Emporous Client libraries.
 
 ### Examples

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,17 +1,24 @@
-# Universal Object Reference Framework
+# Emporous
 
-The UOR Framework describes a single API that can be used to interact with any element within an information system. 
+Emporous describes a single API that can be used to interact with any element within an information system.
 
 ## Where to Start
 
 ### Getting Started Guide
-[Here](https://universalreference.io/docs/category/getting-started) is a simple walk-through with the UOR Client CLI and introduction to UOR Concepts
+
+[Here](https://universalreference.io/docs/category/getting-started) is a simple walk-through with the Emporous Client
+CLI and introduction to Emporous Concepts
 
 ### UOR Client
-The UOR Client libraries and CLI are in located in the [uor-client-go](https://github.com/uor-framework/uor-client-go) repo. The CLI is the reference implementation of the UOR Client libraries. 
+
+The UOR Client libraries and CLI are in located in the [uor-client-go](https://github.com/emporous/emporous-go) repo.
+The CLI is the reference implementation of the Emporous Client libraries.
 
 ### Examples
-There are several examples of how the UOR Client can be used. There is a consolidated [directory](https://github.com/uor-framework/examples) of example use cases for UOR. Please consider adding your use case and an optional demo to that repo.
+
+There are several examples of how the Emporous Client can be used. There is a
+consolidated [directory](https://github.com/emporous/examples) of example use cases for Emporous. Please consider adding
+your use case and an optional demo to that repo.
 
 
 


### PR DESCRIPTION
A couple things of note:

1. This references a google group that may not exist yet
2. This does not change the language or information under the profile README.md, but that will need to be changed in a follow-on PR.
3. `uor-client-go` -> `emporous-go` and the binary would be called `emporous`.
4. `uor-framework` -> `emporous docs`. This was moved to docs because it appears that this is where documentation is kept. I'm also willing to remove this repository because it can be redundant with the content that is already available on the website.


Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>