### PR TITLE
fix: adds sub-teams back under top level teams

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -1,11 +1,11 @@
 orgs:
   emporous:
     admins:
-      - sabre1041
       - afflom
       - jpower432
-      - usrbinkat
       - peribolos
+      - sabre1041
+      - usrbinkat
     billing_email: alexander.flom@gmail.com
     company: ""
     default_repository_permission: read
@@ -88,33 +88,35 @@ orgs:
       client:
         description: "ClI and Libraries"
         privacy: closed
-        members:
-          - d10n
+        maintainers:
           - afflom
           - jpower432
           - sabre1041
+        members:
+          - d10n
         teams:
           client-maintainers:
             description: "CLI and Library codebase maintainers"
             privacy: closed
-            members:
-              - d10n
+            maintainers:
               - afflom
               - jpower432
               - sabre1041
+            members:
+              - d10n
             repos:
               emporous-go: write
               collection-spec: write
       docs:
         description: "Documentation"
         privacy: closed
-        members:
+        maintainers:
           - usrbinkat
         teams:
           docs-maintainers:
             description: "Organization documentation maintainers"
             privacy: closed
-            members:
+            maintainers:
               - usrbinkat
             repos:
               emporous-docs: write

--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -77,7 +77,7 @@ orgs:
           - sfxworks
         teams:
           ci-maintainers:
-            description: "people who maintain Emporous sample configs for CI and demos"
+            description: "Continuous Integration artifact and configuration maintainers"
             privacy: closed
             members:
               - d10n

--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -70,14 +70,14 @@ orgs:
         has_projects: true
     teams:
       ci:
-        description: ""
+        description: "Continuous Integration"
         privacy: closed
-        members: []
-        maintainers: []
-        repos: {}
+        members:
+          - d10n
+          - sfxworks
         teams:
           ci-maintainers:
-            description: "people who maintain Emporous sample configs and demos"
+            description: "people who maintain Emporous sample configs for CI and demos"
             privacy: closed
             members:
               - d10n
@@ -86,33 +86,33 @@ orgs:
               samples: write
               examples: write
       client:
-        description: ""
+        description: "ClI and Libraries"
         privacy: closed
-        members: []
-        maintainers: []
-        repos: {}
+        members:
+          - d10n
+          - afflom
+          - jpower432
+          - sabre1041
         teams:
           client-maintainers:
-            description: "people who maintain client and CLI codebase"
+            description: "CLI and Library codebase maintainers"
             privacy: closed
             members:
               - d10n
               - afflom
               - jpower432
               - sabre1041
-            maintainer: []
             repos:
               emporous-go: write
               collection-spec: write
       docs:
-        description: ""
+        description: "Documentation"
         privacy: closed
-        members: []
-        maintainers: []
-        repos: {}
+        members:
+          - usrbinkat
         teams:
           docs-maintainers:
-            description: "people who maintain organization documentation"
+            description: "Organization documentation maintainers"
             privacy: closed
             members:
               - usrbinkat


### PR DESCRIPTION
Adds sub-teams back under the top-level teams. This was created to fix a configuration error.

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>