### PR TITLE
fix: fix errors in peribolos.yml config under docs-mainters repos

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -122,7 +122,7 @@ orgs:
             repos:
               emporous-docs: write
               emporous.io: write
-              .github: true
+              .github: write
       examples:
         description: "Emporous use case examples and demos"
         privacy: closed


### PR DESCRIPTION
Syntax mistake on peribolos.yml config.

We have this ticket in to validate the config in a CI workflow #26 

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>