### PR TITLE
chore: update org description

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -9,7 +9,7 @@ orgs:
     billing_email: alexander.flom@gmail.com
     company: ""
     default_repository_permission: read
-    description: The smart proxy for container registries
+    description: An open source toolkit to manage different types of content in a single, unified system.
     email: emporous@googlegroups.com
     has_organization_projects: true
     has_repository_projects: true


### PR DESCRIPTION
After seeing the agenda for the upcoming community meeting, I wanted to set up this PR to see could collaborate on way to describe Emporous as a whole. After thinking about it more, I can see how using the term "smart proxy" or probably better "smart gateway" would more represent of a portion of the project or an implementation details and not as effective for messaging as a whole.

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>