### PR TITLE
feat: add an enhancements tracking repo

### DIFF
--- a/peribolos.yaml
+++ b/peribolos.yaml
@@ -71,6 +71,10 @@ orgs:
         default_branch: main
         description: Temporary redirect from universalreference.io to emporous.io
         has_projects: true
+      enhancements:
+        default_branch: main
+        description: Enhancement tracking for Emporous
+        has_projects: true
     teams:
       ci:
         description: "Continuous Integration"


### PR DESCRIPTION
This is a proposal to add an `enhancements` tracking repo. We can use this to define an enhancements process that are large enough to span multiple repositories or discuss overall architecture and design.

An example of an enhancements repo would be https://github.com/kubernetes/enhancements.

An alternative to an enhancements repo may be to just use GitHub Discussions, but it would be nice to have a way to submit and catalog structured proposals.

Signed-off-by: Jennifer Power <barnabei.jennifer@gmail.com>